### PR TITLE
fix: avoid infinite predictions

### DIFF
--- a/lifetimes/fitters/beta_geo_fitter.py
+++ b/lifetimes/fitters/beta_geo_fitter.py
@@ -234,24 +234,32 @@ class BetaGeoFitter(BaseFitter):
 
         r, alpha, a, b = self._unload_params("r", "alpha", "a", "b")
 
-        numerator = (
-            1
-            - ((alpha + T) / (alpha + T + t)) ** (r + frequency)
-            * hyp2f1(
-                r + frequency,
-                b + frequency,
-                a + b + frequency - 1,
-                t / (alpha + T + t),
-            )
-        )
-        numerator *= (a + b + frequency - 1) / (a - 1)
-        denominator = (
-            1
-            + (frequency > 0)
-            * (a / (b + frequency - 1))
-            * ((alpha + T) / (alpha + recency)) ** (r + frequency)
-        )
+        _a = r + frequency
+        _b = b + frequency
+        _c = a + b + frequency - 1
+        _z = t / (alpha + T + t)
 
+        hyp_term = hyp2f1(_a, _b, _c, _z)
+        first_term = (a + b + frequency - 1) / (a - 1)
+        second_term = 1 - ((alpha + T) / (alpha + T + t)) ** (r + frequency) * hyp_term
+
+        # change the second term if the hypergeometric term becomes infinite
+        hyp_term_alt = (
+                np.log(hyp2f1(_c - _a, _c - _b, _c, _z)) + (_c - _a - _b) * np.log(
+            1 - _z)
+        )
+        second_term_alt = 1 - np.exp(
+            hyp_term_alt + np.log((alpha + T) / (alpha + t + T)) * (r + frequency)
+        )
+        second_term = np.where(np.isinf(hyp_term), second_term_alt, second_term)
+
+        numerator = first_term * second_term
+        denominator = (
+                1
+                + (frequency > 0) *
+                (a / (b + frequency - 1)) *
+                ((alpha + T) / (alpha + recency)) ** (r + frequency)
+        )
         return numerator / denominator
 
     def conditional_probability_alive(

--- a/lifetimes/fitters/beta_geo_fitter.py
+++ b/lifetimes/fitters/beta_geo_fitter.py
@@ -243,10 +243,9 @@ class BetaGeoFitter(BaseFitter):
         first_term = (a + b + frequency - 1) / (a - 1)
         second_term = 1 - ((alpha + T) / (alpha + T + t)) ** (r + frequency) * hyp_term
 
-        # change the second term if the hypergeometric term becomes infinite
+        # replace the second term if the hyper geometric term becomes infinite
         hyp_term_alt = (
-                np.log(hyp2f1(_c - _a, _c - _b, _c, _z)) + (_c - _a - _b) * np.log(
-            1 - _z)
+            np.log(hyp2f1(_c - _a, _c - _b, _c, _z)) + (_c - _a - _b) * np.log(1 - _z)
         )
         second_term_alt = 1 - np.exp(
             hyp_term_alt + np.log((alpha + T) / (alpha + t + T)) * (r + frequency)
@@ -255,10 +254,10 @@ class BetaGeoFitter(BaseFitter):
 
         numerator = first_term * second_term
         denominator = (
-                1
-                + (frequency > 0) *
-                (a / (b + frequency - 1)) *
-                ((alpha + T) / (alpha + recency)) ** (r + frequency)
+            1
+            + (frequency > 0) *
+            (a / (b + frequency - 1)) *
+            ((alpha + T) / (alpha + recency)) ** (r + frequency)
         )
         return numerator / denominator
 


### PR DESCRIPTION
The BetaGeoFitter's method `conditional_expected_number_of_purchases_up_to_time` is numerically unstable because of the `scipy.special.hyp2f1` function used in it:

1) When `frequency=0` and `recency=0` and the prediction horizon `t` is above the customer age `T` by a sufficient amount, the `hyp2f1` function produces negative numbers. This results in `RuntimeWarning` when trying to take the `log` from them and leads to `NaN` predictions.
2) When the frequency is very high, the model runs into overflow errors (when a number is too large to store as `float64`), leading to the `inf` output of `hyp2f1` and `inf` prediction as the result.

The [master version](https://github.com/CamDavidsonPilon/lifetimes/blob/41e394923ad72b17b5da93e88cfabab43f51abe2/lifetimes/fitters/beta_geo_fitter.py#L201) at the time of this PR is handling okay the 2) issue but fails with the 1) one. 

Apparently, there were a few attempts ([PR](https://github.com/ea-niibo/lifetimes/pull/1/files) and [PR](https://github.com/CamDavidsonPilon/lifetimes/pull/206)) at fixing the case 1). However, by using them I still ran into errors again in case 2) with high-frequency users. Moreover, the `mpmath.hyp2f1` function does not get broadcasted well with `numpy` and the predict process takes ages.

This PR takes the best from the two worlds and uses one of the approaches above, depending on the case.